### PR TITLE
Add missing home sections for Vercel build

### DIFF
--- a/app/(site)/(home)/_components/arrow_link/page.tsx
+++ b/app/(site)/(home)/_components/arrow_link/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import cls from "@/utils/class_names";
+
+interface ArrowLinkProps {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+}
+
+function ArrowLink({href, children, className}: ArrowLinkProps) {
+    return (
+        <Link
+            href={href}
+            className={cls(
+                "inline-flex items-center gap-1.5 text-base font-medium text-(--neutralColor) transition-colors duration-300 hover:text-(--firstWaveColor) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--firstWaveColor)",
+                className
+            )}
+        >
+            {children}
+        </Link>
+    );
+}
+
+export default ArrowLink;

--- a/app/(site)/(home)/_sections/about/page.tsx
+++ b/app/(site)/(home)/_sections/about/page.tsx
@@ -1,0 +1,38 @@
+import {Suspense} from "react";
+import Container from "@/components/container/page";
+import SectionTitle from "@/components/section_title/page";
+import ArrowLink from "../../_components/arrow_link/page";
+import {HomeAboutSkeleton} from "@/components/skeleton/page";
+
+async function HomeAboutContent() {
+    return (
+        <section>
+            <Container className="min-h-0">
+                <SectionTitle text="A bit about me" />
+                <div className="mx-auto flex max-w-[640px] flex-col gap-6 text-center">
+                    <p className="text-base leading-[1.8] text-(--neutralColor)">
+                        I&apos;m a frontend developer who has been building web applications and interactive
+                        experiences since 2021.
+                    </p>
+                    <p className="text-base leading-[1.8] text-(--neutralColor)">
+                        I enjoy turning ideas into fast, thoughtful and maintainable interfaces, with a focus on
+                        React, Next.js, TypeScript, frontend architecture and performance.
+                    </p>
+                    <div className="pt-2">
+                        <ArrowLink href="/about">More about me →</ArrowLink>
+                    </div>
+                </div>
+            </Container>
+        </section>
+    );
+}
+
+function HomeAbout() {
+    return (
+        <Suspense fallback={<HomeAboutSkeleton />}>
+            <HomeAboutContent />
+        </Suspense>
+    );
+}
+
+export default HomeAbout;

--- a/app/(site)/(home)/_sections/final_cta/page.tsx
+++ b/app/(site)/(home)/_sections/final_cta/page.tsx
@@ -2,7 +2,7 @@ import {Suspense} from "react";
 import Link from "next/link";
 import Container from "@/components/container/page";
 import Button from "@/components/Button/page";
-import ArrowLink from "@/app/(site)/(home)/_components/arrow_link/page";
+import ArrowLink from "../../_components/arrow_link/page";
 import {HomeCtaSkeleton} from "@/components/skeleton/page";
 
 async function FinalCtaContent() {

--- a/app/(site)/(home)/_sections/labs/page.tsx
+++ b/app/(site)/(home)/_sections/labs/page.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import Container from "@/components/container/page";
+import SectionTitle from "@/components/section_title/page";
+import LabsTags from "@/app/labs/_components/labs_tags/page";
+import {getExperimentDescription, getExperimentHref, getExperimentTags, getLabsCategories} from "@/app/labs/_lib/data";
+import cls from "@/utils/class_names";
+
+function HomeLabsCard({
+    title,
+    description,
+    tags,
+    href,
+}: {
+    title: string;
+    description: string;
+    tags: string[];
+    href: string;
+}) {
+    return (
+        <Link
+            href={href}
+            className={cls(
+                "group flex flex-col gap-4 rounded-2xl border border-[rgba(139,139,255,0.14)] bg-[#0c0c12] p-5",
+                "transition-all duration-300 hover:-translate-y-0.5 hover:border-[rgba(139,139,255,0.28)] hover:bg-[#111118]"
+            )}
+        >
+            <h3 className="text-[1.05rem] font-semibold leading-snug text-white">{title}</h3>
+            <p className="line-clamp-3 text-[0.9rem] leading-relaxed text-[#7a7a88]">{description}</p>
+            <LabsTags tags={tags} className="justify-start" />
+            <span className="mt-auto text-sm font-medium text-[#8b8bff] transition-opacity group-hover:opacity-80">
+                Try it →
+            </span>
+        </Link>
+    );
+}
+
+function HomeLabs() {
+    const categories = getLabsCategories();
+
+    const featured = categories
+        .flatMap((category) =>
+            category.experiments
+                .filter((e) => "status" in e && e.status === "live")
+                .map((experiment) => ({
+                    title: experiment.title,
+                    description: getExperimentDescription(experiment),
+                    tags: getExperimentTags(experiment).slice(0, 3),
+                    href: getExperimentHref(category.id, experiment),
+                }))
+        )
+        .slice(-3)
+        .reverse();
+
+    return (
+        <section aria-labelledby="home-labs-heading" className="home-labs">
+            <Container className="min-h-0 !bg-[#050508]">
+                <SectionTitle
+                    as="h2"
+                    id="home-labs-heading"
+                    text="Mahrokh Labs"
+                    className="!text-white"
+                />
+                <p className="-mt-10 mb-12 text-center text-base leading-relaxed text-[#7a7a88] max-tablet:-mt-8 max-tablet:mb-10 max-phone:-mt-4 max-phone:mb-8 max-phone:text-sm">
+                    Interactive experiments, tools and frontend engineering playgrounds.
+                </p>
+
+                <div className="grid grid-cols-3 gap-5 max-small-desktop:grid-cols-2 max-tablet:grid-cols-1">
+                    {featured.map((lab) => (
+                        <HomeLabsCard
+                            key={lab.href}
+                            title={lab.title}
+                            description={lab.description}
+                            tags={lab.tags}
+                            href={lab.href}
+                        />
+                    ))}
+                </div>
+
+                <div className="mt-12 flex justify-center max-phone:mt-8">
+                    <Link
+                        href="/labs"
+                        className="inline-flex items-center gap-1.5 text-base font-medium text-[#8b8bff] transition-opacity duration-300 hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8b8bff]"
+                    >
+                        Explore Labs →
+                    </Link>
+                </div>
+            </Container>
+        </section>
+    );
+}
+
+export default HomeLabs;

--- a/app/(site)/(home)/_sections/selected_work/page.tsx
+++ b/app/(site)/(home)/_sections/selected_work/page.tsx
@@ -3,7 +3,7 @@ import data from "@/data/db.json";
 import Container from "@/components/container/page";
 import SectionTitle from "@/components/section_title/page";
 import SkeletonImage from "@/components/skeleton_image/page";
-import ArrowLink from "@/app/(site)/(home)/_components/arrow_link/page";
+import ArrowLink from "../../_components/arrow_link/page";
 import cls from "@/utils/class_names";
 import type {ProjectType} from "@/app/(site)/projects/type";
 

--- a/app/(site)/(home)/_sections/skills/components/skills_lists/components/skill_list/page.tsx
+++ b/app/(site)/(home)/_sections/skills/components/skills_lists/components/skill_list/page.tsx
@@ -1,5 +1,5 @@
 import Circle, {type CircleFillSpeed} from "@/components/circle/page";
-import {SkillType} from "@/app/(site)/(home)/_sections/skills/type";
+import {SkillType} from "../../../type";
 
 const STAGGER_SECONDS: Record<CircleFillSpeed, number> = {
     fast: 0.04,

--- a/app/(site)/(home)/_sections/skills/components/skills_lists/page.tsx
+++ b/app/(site)/(home)/_sections/skills/components/skills_lists/page.tsx
@@ -3,8 +3,8 @@
 import data from "@/data/db.json";
 import {useEffect, useMemo, useState} from "react";
 import {useInView} from "react-intersection-observer";
-import SkillsList from "@/app/(site)/(home)/_sections/skills/components/skills_lists/components/skill_list/page";
-import {SkillType} from "@/app/(site)/(home)/_sections/skills/type";
+import SkillsList from "./components/skill_list/page";
+import {SkillType} from "../../type";
 import type {CircleFillSpeed} from "@/components/circle/page";
 
 const FILL_SPEED: CircleFillSpeed = "med";

--- a/app/(site)/(home)/_sections/skills/page.tsx
+++ b/app/(site)/(home)/_sections/skills/page.tsx
@@ -1,6 +1,6 @@
 import Container from "@/components/container/page";
 import SectionTitle from "@/components/section_title/page";
-import SkillsLists from "@/app/(site)/(home)/_sections/skills/components/skills_lists/page";
+import SkillsLists from "./components/skills_lists/page";
 
 function Skills() {
   return (

--- a/app/(site)/(home)/page.tsx
+++ b/app/(site)/(home)/page.tsx
@@ -1,11 +1,11 @@
 import type {Metadata} from "next";
 import metadataCreator from "@/utils/server-metadata";
-import View from "@/app/(site)/(home)/_sections/view/page";
-import SelectedWork from "@/app/(site)/(home)/_sections/selected_work/page";
-import HomeLabs from "@/app/(site)/(home)/_sections/labs/page";
-import Skills from "@/app/(site)/(home)/_sections/skills/page";
-import HomeAbout from "@/app/(site)/(home)/_sections/about/page";
-import FinalCta from "@/app/(site)/(home)/_sections/final_cta/page";
+import View from "./_sections/view/page";
+import SelectedWork from "./_sections/selected_work/page";
+import HomeLabs from "./_sections/labs/page";
+import Skills from "./_sections/skills/page";
+import HomeAbout from "./_sections/about/page";
+import FinalCta from "./_sections/final_cta/page";
 import JsonLdScript from "@/components/seo/jsonld_script";
 import {getPersonJsonLd, getWebsiteJsonLd} from "@/utils/seo/jsonld";
 


### PR DESCRIPTION
## Summary
- Production `main` imported Labs, About, and ArrowLink but those files were never committed, which broke the Vercel build.
- Adds the missing files and switches home-page imports to relative paths.

## Test plan
- [ ] Vercel production build succeeds
- [ ] Home page renders Selected Work, Labs, About, and CTA links